### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,17 +3,14 @@
     "license": "GPL-3.0",
     "type": "magento-module",
     "description": "This extension adds a PSR-0 autoloader before the Varien autoloader",
-    "authors":[
-            {
-                "name":"Michael Ryvlin"
-            },
-            {
-                "name":"Damian Luszczymak"
-            }
-        ],
-    "require": {
-        "magento-hackathon/magento-composer-installer": "*"
-    },
+    "authors": [
+        {
+            "name":"Michael Ryvlin"
+        },
+        {
+            "name":"Damian Luszczymak"
+        }
+    ],
     "require-dev": {
         "firegento/mage-ci": "master-dev",
         "phpunit/phpunit": "~4.4"


### PR DESCRIPTION
As far as I can tell, there is no need to include magento-composer-installer as a dependency for the PSR0-autoloader.
