### PR TITLE
Using with magento-composer-installer

### DIFF
--- a/app/code/community/Hackathon/PSR0Autoloader/Model/Observer.php
+++ b/app/code/community/Hackathon/PSR0Autoloader/Model/Observer.php
@@ -23,6 +23,7 @@ class Hackathon_PSR0Autoloader_Model_Observer extends Mage_Core_Model_Observer {
 	protected function getComposerVendorPath(){
 		$node = Mage::getConfig()->getNode(self::CONFIG_PATH_COMPOSER_VENDOR_PATH);
 		$path = str_replace( '{{root_dir}}', Mage::getBaseDir(), $node);
+		$path = realpath($path);
 		return $path;
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -1,19 +1,16 @@
 {
-    "name": "hgati/firegento-psr0autoloader",
-    "license": "GPL-3.0",
+    "name": "firegento/psr0autoloader",
+    "licenses": ["MIT", "GPL-3.0"],
     "type": "magento-module",
     "description": "This extension adds a PSR-0 autoloader before the Varien autoloader",
-    "authors":[
-            {
-                "name":"Michael Ryvlin"
-            },
-            {
-                "name":"Damian Luszczymak"
-            }
-        ],
-    "require": {
-        "magento-hackathon/magento-composer-installer": "*"
-    },
+    "authors": [
+        {
+            "name":"Michael Ryvlin"
+        },
+        {
+            "name":"Damian Luszczymak"
+        }
+    ],
     "require-dev": {
         "firegento/mage-ci": "master-dev",
         "phpunit/phpunit": "~4.4"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "firegento/psr0autoloader",
+    "name": "hgati/firegento-psr0autoloader",
     "license": "GPL-3.0",
     "type": "magento-module",
     "description": "This extension adds a PSR-0 autoloader before the Varien autoloader",


### PR DESCRIPTION
My magento directory structure is.......
there is vendor dir above magento root dir(in my case htdocs)

+htdocs
++++app
++++js
++++lib
++++media
++++shell
++++skin
++++var
+vendor
+composer.json
+composer.lock

so It should support relative path as below.
<global>
<composer_vendor_path><![CDATA[{{root_dir}}/../vendor]]></composer_vendor_path>
</global>
