### PR TITLE
Listen on additional event which is triggered after resource_get_tabl…

### DIFF
--- a/app/code/community/Hackathon/PSR0Autoloader/etc/config.xml
+++ b/app/code/community/Hackathon/PSR0Autoloader/etc/config.xml
@@ -12,6 +12,14 @@
 			</psr0autoloader>
 		</models>
 		<events>
+			<core_collection_abstract_load_before>
+				<observers>
+					<psr0autoloader>
+						<class>Hackathon_PSR0Autoloader_Model_Observer</class>
+						<method>addAutoloader</method>
+					</psr0autoloader>
+				</observers>
+			</core_collection_abstract_load_before>
 			<resource_get_tablename>
 				<observers>
 					<psr0autoloader>


### PR DESCRIPTION
…ename, but appears to be the first with a working configuration available, so that event are dispatched to observers correctly.